### PR TITLE
Fixed multiple write by writing a DWORD over PCIe

### DIFF
--- a/pypcie/bar.py
+++ b/pypcie/bar.py
@@ -52,10 +52,11 @@ class Bar(object):
         :param int data: double word to write to the given BAR offset.
         """
         self.__check_offset(offset)
-        self.__map.seek(offset)
-        reg = pack("<L", data)
-        # write to map. no ret. check: ValueError/TypeError is raised on error
-        self.__map.write(reg)
+        # self.__map.seek(offset)
+        # create memory view and cast it as integer
+        mv   = memoryview(self.__map)
+        mmap = mv.cast('I')
+        mmap[int(offset/4)] = data
         # Flush current page for immediate update.
         page_offset = offset & (~(PAGESIZE - 1) & 0xffffffff)
         self.__map.flush(page_offset, PAGESIZE)

--- a/pypcie/bar.py
+++ b/pypcie/bar.py
@@ -42,8 +42,10 @@ class Bar(object):
 
         """
         self.__check_offset(offset)
-        reg = self.__map[offset:offset+4]
-        return unpack("<L", reg)[0]
+        mv   = memoryview(self.__map)
+        mmap = mv.cast('I')
+        reg  = mmap[int(offset/4)]
+        return reg
 
     def write(self, offset: int, data: int):
         """ Write a 32 bit / double word value to offset.


### PR DESCRIPTION
Hi Heiko,

I've tried to use the module on my Kintex US board for configuring the SPI core, but run into a problem that the DWORD write transaction over PCIe is translated to 4 AXI transactions in FPGA.

This merge request fixes the problem by casting the memory mapped register space as array of integers.